### PR TITLE
Rearrange readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Setup 
 
-You'll probably need to additionally install these packages:
+These instructions are intended for use on Linux (including WSL) only.
+
+You'll probably need to install these packages:
 
 ```
 libboost-dev-all protobuf-compiler ninja-build
@@ -12,7 +14,7 @@ Use this one-line cmake incantation:
 cmake -B build -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
 ```
 
-Uncomment the majority of src/gtsam_tags_node.cpp and fix any errors before using cmake to build.
+Uncomment the majority of src/gtsam_tags_node.cpp and fix any errors before using cmake to build. Depending on your RAM, you may need to use `-j <number>` to control the number of jobs.
 
 # Running a photon sim example
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Uncomment the majority of src/gtsam_tags_node.cpp and fix any errors before usin
 
 I visualize output data usually using advantagescope. The 3d visualizer is great.
 
-In order for the dats transfer to work properly, start advantagescope, then sim, then run gtsam-node. If using the /robot/multi_tag_pose topic in advantagescope, note that it will only update while tags are visible.
+In order for the data transfer to work properly, start advantagescope, then sim, then run gtsam-node. The /SmartDashboard/VisionSystemSim-main/Sim Field/Gtsam Robot topic will show the fused pose of the robot.
 
 # NT API
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,26 @@
 # Setup 
 
-One-line cmake incantation
+You'll probably need to additionally install these packages:
+
+```
+libboost-dev-all protobuf-compiler ninja-build
+```
+
+Use this one-line cmake incantation:
 
 ```
 cmake -B build -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
 ```
+
+Uncomment the majority of src/gtsam_tags_node.cpp and fix any errors before using cmake to build.
 
 # Running a photon sim example
 
 [This sim example](https://github.com/PhotonVision/champs_2024/tree/gtsam-testing/sim_projects/apriltag_yaw_only) in the gtsam-testing branch is set up to provide simulated data to the current build of gtsam-playground. Just run it as a robot simulation project! Until I get CLI working, the gtsam node NT server IP address will need to be manually changed per-machine this is tested on.
 
 I visualize output data usually using advantagescope. The 3d visualizer is great.
+
+In order for the dats transfer to work properly, start advantagescope, then sim, then run gtsam-node. If using the /robot/multi_tag_pose topic in advantagescope, note that it will only update while tags are visible.
 
 # NT API
 
@@ -25,14 +35,6 @@ Publishers
 - /cam/gtsam_predicted_corners: Expected tag corner locations. Not latency compensated, only valid when not moving.
 - /cam/update_dt_ms: How long the update loop took to add all new factors and re-optimize.
 - /cam/std_dev: Standard deviations for pose estimate, order is [rx ry rz tx ty tz]
-
-# Packages
-
-You'll probably need to additionally install these packages:
-
-```
-libboost-all-dev protobuf-compiler ninja-build
-```
 
 # Notes
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Use this one-line cmake incantation:
 cmake -B build -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo
 ```
 
-Uncomment the majority of src/gtsam_tags_node.cpp and fix any errors before using cmake to build. Depending on your RAM, you may need to use `-j <number>` to control the number of jobs.
+ Depending on your RAM, you may need to use `-j <number>` to control the number of jobs when building.
 
 # Running a photon sim example
 


### PR DESCRIPTION
Puts the packages up front in setup, adds ninja-build, and presents the entire process apart from stuff that is easily googlable or can be safely assumed (how to actually build in cmake, how to run the executable, how to clone submodules, etc.)